### PR TITLE
Brgrwrld 4 ecr repo perms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -322,7 +322,7 @@ resource "aws_lb" "loadbalancer" {
 resource "aws_lb_target_group" "lb_target_group" {
   name        = "burgerworld-hello-ecs"
   port        = "1337"
-  protocol    = "HTTPS"
+  protocol    = "TCP"
   vpc_id      = "vpc-ff04929b"
   target_type = "ip"
 
@@ -336,13 +336,13 @@ resource "aws_lb_target_group" "lb_target_group" {
 }
 
 resource "aws_lb_listener" "lb_listener" {
+
   default_action {
     target_group_arn = aws_lb_target_group.lb_target_group.id
     type             = "forward"
   }
 
-  certificate_arn   = "arn:aws:acm:us-east-1:379683964026:certificate/f6dc2998-af1b-41e8-87a6-b4b2c4d6a0d8"
   load_balancer_arn = aws_lb.loadbalancer.arn
   port              = "1337"
-  protocol          = "HTTPS"
+  protocol          = "TCP"
 }

--- a/main.tf
+++ b/main.tf
@@ -313,27 +313,23 @@ resource "aws_ecs_cluster" "burgerworld-hello-ecs-ecs-cluster" {
 resource "aws_lb" "loadbalancer" {
   load_balancer_type         = var.burgerworld-hello-ecs-loadbalancer-type
   internal                   = "false" # tfsec:ignore:aws-elb-alb-not-public
-  name                       = "${var.burgerworld_hello_ecs_app_name}-ecs-cluster"
+  name                       = "${var.burgerworld_hello_ecs_app_name}-cluster"
   subnets                    = var.burgerworld-hello-ecs-alb-subnets
   security_groups            = [aws_security_group.ecs-sg.id]
   drop_invalid_header_fields = "true"
 }
 
-
 resource "aws_lb_target_group" "lb_target_group" {
-  name        = "openapi-target-alb-name"
-  port        = "80"
-  protocol    = "HTTP"
-  vpc_id      = "vpc-000851116d62e0c13" # CHNAGE THIS
+  name        = "burgerworld-hello-ecs"
+  port        = "1337"
+  protocol    = "HTTPS"
+  vpc_id      = "vpc-ff04929b"
   target_type = "ip"
 
-
-  #STEP 1 - ECS task Running
   health_check {
     healthy_threshold   = "3"
     interval            = "10"
     port                = "1337"
-    path                = "/static/hello.txt"
     protocol            = "TCP"
     unhealthy_threshold = "3"
   }
@@ -345,7 +341,7 @@ resource "aws_lb_listener" "lb_listener" {
     type             = "forward"
   }
 
-  #certificate_arn   = "arn:aws:acm:us-east-1:689019322137:certificate/9fcdad0a-7350-476c-b7bd-3a530cf03090"
+  certificate_arn   = "arn:aws:acm:us-east-1:379683964026:certificate/f6dc2998-af1b-41e8-87a6-b4b2c4d6a0d8"
   load_balancer_arn = aws_lb.loadbalancer.arn
   port              = "1337"
   protocol          = "HTTPS"

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,27 @@ variable "burgerworld_hello_ecs_vpc_id" {
   type        = string
   default     = "vpc-ff04929b"
 }
+
+variable "burgerworld-hello-ecs-ecs-cluster-container-insights-enabled" {
+  description = "enable ecs container insights"
+  type        = string
+  default     = "true"
+}
+
+variable "burgerworld-hello-ecs-autoscaling-group-vpc-zone-identifier" {
+  description = "list of private subnets to launch instances in"
+  type        = list(any)
+  default     = ["subnet-070e5fb1f79ff9ec3", "subnet-0acccb37fbb30454d"]
+}
+
+variable "burgerworld-hello-ecs-alb-subnets" {
+  description = "list of private subnets to attach to alb"
+  type        = list(any)
+  default     = ["subnet-070e5fb1f79ff9ec3", "subnet-0acccb37fbb30454d"]
+}
+
+variable "burgerworld-hello-ecs-loadbalancer-type" {
+  description = "type of load balancer to launch"
+  type        = string
+  default     = "application"
+}


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # aws_autoscaling_group.failure_analysis_ecs_asg will be created
  + resource "aws_autoscaling_group" "failure_analysis_ecs_asg" {
      + arn                       = (known after apply)
      + availability_zones        = (known after apply)
      + default_cooldown          = (known after apply)
      + desired_capacity          = 2
      + force_delete              = false
      + force_delete_warm_pool    = false
      + health_check_grace_period = 300
      + health_check_type         = "EC2"
      + id                        = (known after apply)
      + launch_configuration      = (known after apply)
      + max_size                  = 10
      + metrics_granularity       = "1Minute"
      + min_size                  = 1
      + name                      = "burgerworld-hello-ecs-dev-ecs-cluster"
      + name_prefix               = (known after apply)
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)
      + vpc_zone_identifier       = [
          + "subnet-070e5fb1f79ff9ec3",
          + "subnet-0acccb37fbb30454d",
        ]
      + wait_for_capacity_timeout = "10m"
    }

  # aws_ecs_cluster.burgerworld-hello-ecs-ecs-cluster will be created
  + resource "aws_ecs_cluster" "burgerworld-hello-ecs-ecs-cluster" {
      + arn                = (known after apply)
      + capacity_providers = (known after apply)
      + id                 = (known after apply)
      + name               = "burgerworld-hello-ecs-cluster"
      + tags               = {
          + "Environment" = "dev"
          + "Name"        = "burgerworld-hello-ecs-ecs-cluster"
        }
      + tags_all           = {
          + "Environment" = "dev"
          + "Name"        = "burgerworld-hello-ecs-ecs-cluster"
        }

      + default_capacity_provider_strategy {
          + base              = (known after apply)
          + capacity_provider = (known after apply)
          + weight            = (known after apply)
        }

      + setting {
          + name  = "containerInsights"
          + value = "enabled"
        }
    }

  # aws_launch_configuration.ecs_launch_config will be created
  + resource "aws_launch_configuration" "ecs_launch_config" {
      + arn                         = (known after apply)
      + associate_public_ip_address = false
      + ebs_optimized               = (known after apply)
      + enable_monitoring           = true
      + iam_instance_profile        = "ecs-agent"
      + id                          = (known after apply)
      + image_id                    = "ami-0f863d7367abe5d6f"
      + instance_type               = "t2.micro"
      + key_name                    = (known after apply)
      + name                        = (known after apply)
      + name_prefix                 = (known after apply)
      + security_groups             = [
          + "sg-04247ba0c6d5312d8",
        ]
      + user_data                   = "14540f0db3f4a5530f4a4d91dae9421bdd417597"

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + no_device             = (known after apply)
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = "required"
        }

      + root_block_device {
          + delete_on_termination = true
          + encrypted             = true
          + iops                  = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = 20
          + volume_type           = "standard"
        }
    }

  # aws_lb.loadbalancer will be created
  + resource "aws_lb" "loadbalancer" {
      + arn                        = (known after apply)
      + arn_suffix                 = (known after apply)
      + desync_mitigation_mode     = "defensive"
      + dns_name                   = (known after apply)
      + drop_invalid_header_fields = true
      + enable_deletion_protection = false
      + enable_http2               = true
      + enable_waf_fail_open       = false
      + id                         = (known after apply)
      + idle_timeout               = 60
      + internal                   = false
      + ip_address_type            = (known after apply)
      + load_balancer_type         = "application"
      + name                       = "burgerworld-hello-ecs-cluster"
      + security_groups            = [
          + "sg-04247ba0c6d5312d8",
        ]
      + subnets                    = [
          + "subnet-070e5fb1f79ff9ec3",
          + "subnet-0acccb37fbb30454d",
        ]
      + tags_all                   = (known after apply)
      + vpc_id                     = (known after apply)
      + zone_id                    = (known after apply)

      + subnet_mapping {
          + allocation_id        = (known after apply)
          + ipv6_address         = (known after apply)
          + outpost_id           = (known after apply)
          + private_ipv4_address = (known after apply)
          + subnet_id            = (known after apply)
        }
    }

  # aws_lb_listener.lb_listener will be created
  + resource "aws_lb_listener" "lb_listener" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 1337
      + protocol          = "TCP"
      + ssl_policy        = (known after apply)
      + tags_all          = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # aws_lb_target_group.lb_target_group will be created
  + resource "aws_lb_target_group" "lb_target_group" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = false
      + deregistration_delay               = "300"
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = "burgerworld-hello-ecs"
      + port                               = 1337
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "TCP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = (known after apply)
      + target_type                        = "ip"
      + vpc_id                             = "vpc-ff04929b"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 10
          + matcher             = (known after apply)
          + path                = (known after apply)
          + port                = "1337"
          + protocol            = "TCP"
          + timeout             = (known after apply)
          + unhealthy_threshold = 3
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + cookie_name     = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # aws_security_group.ecs-sg will be updated in-place
  ~ resource "aws_security_group" "ecs-sg" {
        id                     = "sg-04247ba0c6d5312d8"
      ~ ingress                = [
          - {
              - cidr_blocks      = [
                  - "72.50.221.50/32",
                ]
              - description      = "ssh access"
              - from_port        = 22
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 22
            },
            # (1 unchanged element hidden)
        ]
        name                   = "terraform-20220620231909384100000001"
        tags                   = {}
        # (8 unchanged attributes hidden)
    }

Plan: 6 to add, 1 to change, 0 to destroy.


------------------------------------------------------------------------

Cost Estimation:

Resources: 3 of 9 estimated
           $110.7200000000000088/mo +$109.720000000000008
```