### PR TITLE
BRGRWRLD-4 correct naming

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,7 @@ resource "aws_security_group" "ecs-sg" {
 #######
 # ASG #
 #######
-resource "aws_launch_configuration" "ecs_launch_config" {
+resource "aws_launch_configuration" "burgerworld-hello-ecs-launch-configuration" {
   image_id             = "ami-0f863d7367abe5d6f"
   iam_instance_profile = aws_iam_instance_profile.ecs-agent.name
   security_groups      = [aws_security_group.ecs-sg.id]
@@ -279,10 +279,10 @@ resource "aws_launch_configuration" "ecs_launch_config" {
   }
 }
 
-resource "aws_autoscaling_group" "failure_analysis_ecs_asg" {
+resource "aws_autoscaling_group" "burgerworld-hello-ecs-asg" {
   name                      = "${var.burgerworld_hello_ecs_app_name}-${var.burgerworld_hello_ecs_deployment_environment}-ecs-cluster"
   vpc_zone_identifier       = var.burgerworld-hello-ecs-autoscaling-group-vpc-zone-identifier
-  launch_configuration      = aws_launch_configuration.ecs_launch_config.name
+  launch_configuration      = aws_launch_configuration.burgerworld-hello-ecs-launch-configuration.name
   desired_capacity          = 2
   min_size                  = 1
   max_size                  = 10
@@ -310,7 +310,7 @@ resource "aws_ecs_cluster" "burgerworld-hello-ecs-ecs-cluster" {
 # ALB #
 #######
 
-resource "aws_lb" "loadbalancer" {
+resource "aws_lb" "burgerworld-hello-ecs-loadbalancer" {
   load_balancer_type         = var.burgerworld-hello-ecs-loadbalancer-type
   internal                   = "false" # tfsec:ignore:aws-elb-alb-not-public
   name                       = "${var.burgerworld_hello_ecs_app_name}-cluster"
@@ -319,7 +319,7 @@ resource "aws_lb" "loadbalancer" {
   drop_invalid_header_fields = "true"
 }
 
-resource "aws_lb_target_group" "lb_target_group" {
+resource "aws_lb_target_group" "burgerworld-hello-ecs-lb-target-group" {
   name        = "burgerworld-hello-ecs"
   port        = "1337"
   protocol    = "TCP"
@@ -335,14 +335,14 @@ resource "aws_lb_target_group" "lb_target_group" {
   }
 }
 
-resource "aws_lb_listener" "lb_listener" {
+resource "aws_lb_listener" "burgerworld-hello-ecs-alb-listener" {
 
   default_action {
-    target_group_arn = aws_lb_target_group.lb_target_group.id
+    target_group_arn = aws_lb_target_group.burgerworld-hello-ecs-lb-target-group.id
     type             = "forward"
   }
 
-  load_balancer_arn = aws_lb.loadbalancer.arn
+  load_balancer_arn = aws_lb.burgerworld-hello-ecs-loadbalancer.arn
   port              = "1337"
   protocol          = "TCP"
 }


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # aws_autoscaling_group.burgerworld-hello-ecs-asg will be created
  + resource "aws_autoscaling_group" "burgerworld-hello-ecs-asg" {
      + arn                       = (known after apply)
      + availability_zones        = (known after apply)
      + default_cooldown          = (known after apply)
      + desired_capacity          = 2
      + force_delete              = false
      + force_delete_warm_pool    = false
      + health_check_grace_period = 300
      + health_check_type         = "EC2"
      + id                        = (known after apply)
      + launch_configuration      = (known after apply)
      + max_size                  = 10
      + metrics_granularity       = "1Minute"
      + min_size                  = 1
      + name                      = "burgerworld-hello-ecs-dev-ecs-cluster"
      + name_prefix               = (known after apply)
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)
      + vpc_zone_identifier       = [
          + "subnet-070e5fb1f79ff9ec3",
          + "subnet-0acccb37fbb30454d",
        ]
      + wait_for_capacity_timeout = "10m"
    }

  # aws_autoscaling_group.failure_analysis_ecs_asg will be destroyed
  # (because aws_autoscaling_group.failure_analysis_ecs_asg is not in configuration)
  - resource "aws_autoscaling_group" "failure_analysis_ecs_asg" {
      - arn                       = "arn:aws:autoscaling:us-east-1:379683964026:autoScalingGroup:179b1947-ec00-426f-bf6f-7bfe5aa55cae:autoScalingGroupName/burgerworld-hello-ecs-dev-ecs-cluster" -> null
      - availability_zones        = [
          - "us-east-1a",
          - "us-east-1c",
        ] -> null
      - capacity_rebalance        = false -> null
      - default_cooldown          = 300 -> null
      - desired_capacity          = 2 -> null
      - enabled_metrics           = [] -> null
      - force_delete              = false -> null
      - force_delete_warm_pool    = false -> null
      - health_check_grace_period = 300 -> null
      - health_check_type         = "EC2" -> null
      - id                        = "burgerworld-hello-ecs-dev-ecs-cluster" -> null
      - launch_configuration      = "terraform-20220623021322619500000001" -> null
      - load_balancers            = [] -> null
      - max_instance_lifetime     = 0 -> null
      - max_size                  = 10 -> null
      - metrics_granularity       = "1Minute" -> null
      - min_size                  = 1 -> null
      - name                      = "burgerworld-hello-ecs-dev-ecs-cluster" -> null
      - protect_from_scale_in     = false -> null
      - service_linked_role_arn   = "arn:aws:iam::379683964026:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" -> null
      - suspended_processes       = [] -> null
      - target_group_arns         = [] -> null
      - termination_policies      = [] -> null
      - vpc_zone_identifier       = [
          - "subnet-070e5fb1f79ff9ec3",
          - "subnet-0acccb37fbb30454d",
        ] -> null
      - wait_for_capacity_timeout = "10m" -> null
    }

  # aws_launch_configuration.burgerworld-hello-ecs-launch-configuration will be created
  + resource "aws_launch_configuration" "burgerworld-hello-ecs-launch-configuration" {
      + arn                         = (known after apply)
      + associate_public_ip_address = false
      + ebs_optimized               = (known after apply)
      + enable_monitoring           = true
      + iam_instance_profile        = "ecs-agent"
      + id                          = (known after apply)
      + image_id                    = "ami-0f863d7367abe5d6f"
      + instance_type               = "t2.micro"
      + key_name                    = (known after apply)
      + name                        = (known after apply)
      + name_prefix                 = (known after apply)
      + security_groups             = [
          + "sg-04247ba0c6d5312d8",
        ]
      + user_data                   = "14540f0db3f4a5530f4a4d91dae9421bdd417597"

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + no_device             = (known after apply)
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = "required"
        }

      + root_block_device {
          + delete_on_termination = true
          + encrypted             = true
          + iops                  = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = 20
          + volume_type           = "standard"
        }
    }

  # aws_launch_configuration.ecs_launch_config will be destroyed
  # (because aws_launch_configuration.ecs_launch_config is not in configuration)
  - resource "aws_launch_configuration" "ecs_launch_config" {
      - arn                              = "arn:aws:autoscaling:us-east-1:379683964026:launchConfiguration:14c0405c-9c42-404d-8643-0801d1e89128:launchConfigurationName/terraform-20220623021322619500000001" -> null
      - associate_public_ip_address      = false -> null
      - ebs_optimized                    = false -> null
      - enable_monitoring                = true -> null
      - iam_instance_profile             = "ecs-agent" -> null
      - id                               = "terraform-20220623021322619500000001" -> null
      - image_id                         = "ami-0f863d7367abe5d6f" -> null
      - instance_type                    = "t2.micro" -> null
      - name                             = "terraform-20220623021322619500000001" -> null
      - name_prefix                      = "terraform-" -> null
      - security_groups                  = [
          - "sg-04247ba0c6d5312d8",
        ] -> null
      - user_data                        = "14540f0db3f4a5530f4a4d91dae9421bdd417597" -> null
      - vpc_classic_link_security_groups = [] -> null

      - root_block_device {
          - delete_on_termination = true -> null
          - encrypted             = true -> null
          - iops                  = 0 -> null
          - throughput            = 0 -> null
          - volume_size           = 20 -> null
          - volume_type           = "standard" -> null
        }
    }

  # aws_lb.burgerworld-hello-ecs-loadbalancer will be created
  + resource "aws_lb" "burgerworld-hello-ecs-loadbalancer" {
      + arn                        = (known after apply)
      + arn_suffix                 = (known after apply)
      + desync_mitigation_mode     = "defensive"
      + dns_name                   = (known after apply)
      + drop_invalid_header_fields = true
      + enable_deletion_protection = false
      + enable_http2               = true
      + enable_waf_fail_open       = false
      + id                         = (known after apply)
      + idle_timeout               = 60
      + internal                   = false
      + ip_address_type            = (known after apply)
      + load_balancer_type         = "application"
      + name                       = "burgerworld-hello-ecs-cluster"
      + security_groups            = [
          + "sg-04247ba0c6d5312d8",
        ]
      + subnets                    = [
          + "subnet-070e5fb1f79ff9ec3",
          + "subnet-0acccb37fbb30454d",
        ]
      + tags_all                   = (known after apply)
      + vpc_id                     = (known after apply)
      + zone_id                    = (known after apply)

      + subnet_mapping {
          + allocation_id        = (known after apply)
          + ipv6_address         = (known after apply)
          + outpost_id           = (known after apply)
          + private_ipv4_address = (known after apply)
          + subnet_id            = (known after apply)
        }
    }

  # aws_lb.loadbalancer will be destroyed
  # (because aws_lb.loadbalancer is not in configuration)
  - resource "aws_lb" "loadbalancer" {
      - arn                        = "arn:aws:elasticloadbalancing:us-east-1:379683964026:loadbalancer/app/burgerworld-hello-ecs-cluster/b5d16c4ac3846dc2" -> null
      - arn_suffix                 = "app/burgerworld-hello-ecs-cluster/b5d16c4ac3846dc2" -> null
      - desync_mitigation_mode     = "defensive" -> null
      - dns_name                   = "burgerworld-hello-ecs-cluster-185707887.us-east-1.elb.amazonaws.com" -> null
      - drop_invalid_header_fields = true -> null
      - enable_deletion_protection = false -> null
      - enable_http2               = true -> null
      - enable_waf_fail_open       = false -> null
      - id                         = "arn:aws:elasticloadbalancing:us-east-1:379683964026:loadbalancer/app/burgerworld-hello-ecs-cluster/b5d16c4ac3846dc2" -> null
      - idle_timeout               = 60 -> null
      - internal                   = false -> null
      - ip_address_type            = "ipv4" -> null
      - load_balancer_type         = "application" -> null
      - name                       = "burgerworld-hello-ecs-cluster" -> null
      - security_groups            = [
          - "sg-04247ba0c6d5312d8",
        ] -> null
      - subnets                    = [
          - "subnet-070e5fb1f79ff9ec3",
          - "subnet-0acccb37fbb30454d",
        ] -> null
      - tags                       = {} -> null
      - tags_all                   = {} -> null
      - vpc_id                     = "vpc-ff04929b" -> null
      - zone_id                    = "Z35SXDOTRQ7X7K" -> null

      - access_logs {
          - enabled = false -> null
        }

      - subnet_mapping {
          - subnet_id = "subnet-070e5fb1f79ff9ec3" -> null
        }
      - subnet_mapping {
          - subnet_id = "subnet-0acccb37fbb30454d" -> null
        }
    }

  # aws_lb_listener.burgerworld-hello-ecs-alb-listener will be created
  + resource "aws_lb_listener" "burgerworld-hello-ecs-alb-listener" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 1337
      + protocol          = "TCP"
      + ssl_policy        = (known after apply)
      + tags_all          = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # aws_lb_target_group.burgerworld-hello-ecs-lb-target-group will be created
  + resource "aws_lb_target_group" "burgerworld-hello-ecs-lb-target-group" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = false
      + deregistration_delay               = "300"
      + id                                 = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancing_algorithm_type      = (known after apply)
      + name                               = "burgerworld-hello-ecs"
      + port                               = 1337
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "TCP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = (known after apply)
      + target_type                        = "ip"
      + vpc_id                             = "vpc-ff04929b"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 10
          + matcher             = (known after apply)
          + path                = (known after apply)
          + port                = "1337"
          + protocol            = "TCP"
          + timeout             = (known after apply)
          + unhealthy_threshold = 3
        }

      + stickiness {
          + cookie_duration = (known after apply)
          + cookie_name     = (known after apply)
          + enabled         = (known after apply)
          + type            = (known after apply)
        }
    }

  # aws_lb_target_group.lb_target_group will be destroyed
  # (because aws_lb_target_group.lb_target_group is not in configuration)
  - resource "aws_lb_target_group" "lb_target_group" {
      - arn                                = "arn:aws:elasticloadbalancing:us-east-1:379683964026:targetgroup/burgerworld-hello-ecs/11ab12854165be25" -> null
      - arn_suffix                         = "targetgroup/burgerworld-hello-ecs/11ab12854165be25" -> null
      - connection_termination             = false -> null
      - deregistration_delay               = "300" -> null
      - id                                 = "arn:aws:elasticloadbalancing:us-east-1:379683964026:targetgroup/burgerworld-hello-ecs/11ab12854165be25" -> null
      - lambda_multi_value_headers_enabled = false -> null
      - name                               = "burgerworld-hello-ecs" -> null
      - port                               = 1337 -> null
      - preserve_client_ip                 = "false" -> null
      - protocol                           = "TCP" -> null
      - proxy_protocol_v2                  = false -> null
      - slow_start                         = 0 -> null
      - tags                               = {} -> null
      - tags_all                           = {} -> null
      - target_type                        = "ip" -> null
      - vpc_id                             = "vpc-ff04929b" -> null

      - health_check {
          - enabled             = true -> null
          - healthy_threshold   = 3 -> null
          - interval            = 10 -> null
          - port                = "1337" -> null
          - protocol            = "TCP" -> null
          - timeout             = 10 -> null
          - unhealthy_threshold = 3 -> null
        }

      - stickiness {
          - cookie_duration = 0 -> null
          - enabled         = false -> null
          - type            = "source_ip" -> null
        }
    }

Plan: 5 to add, 0 to change, 4 to destroy.


------------------------------------------------------------------------

Cost Estimation:

Resources: 5 of 11 estimated
           $110.7200000000000088/mo +$0.0
```